### PR TITLE
Update Gemfile line to include '~> 0.10'

### DIFF
--- a/content/docs/installation.md
+++ b/content/docs/installation.md
@@ -20,7 +20,7 @@ PushType takes advantage of modern features of PostgreSQL, which in turn require
 Assuming you have a Rails app ready to go, add the following line to the `Gemfile`:
 
     #!ruby
-    gem 'push_type'
+    gem 'push_type', '~> 0.10'
 
 Then execute from the terminal:
 


### PR DESCRIPTION
Without this, Bundler tried to install version 0.1. I think this is because of the way version strings are compared.